### PR TITLE
fix: noita再起動時に茜ちゃんがしゃべらない問題を修正した

### DIFF
--- a/files/entities/sounds/damage_received/heavy_damage_voice.xml
+++ b/files/entities/sounds/damage_received/heavy_damage_voice.xml
@@ -1,4 +1,4 @@
-<Entity name="start_voice">
+<Entity name="damage_received.heavy_damage_voice">
   <AudioComponent file="mods/akanechan_voice/files/audio/mod_voices.snd"
     event_root="akanechan"
     audio_physics_material="character_player"

--- a/files/entities/sounds/damage_received/low_helth_damage_voice.xml
+++ b/files/entities/sounds/damage_received/low_helth_damage_voice.xml
@@ -1,4 +1,4 @@
-<Entity name="start_voice">
+<Entity name="damage_received.low_helth_damage_voice">
   <AudioComponent file="mods/akanechan_voice/files/audio/mod_voices.snd"
     event_root="akanechan"
     audio_physics_material="character_player"

--- a/files/entities/sounds/damage_received/mild_damage_voice.xml
+++ b/files/entities/sounds/damage_received/mild_damage_voice.xml
@@ -1,4 +1,4 @@
-<Entity name="start_voice">
+<Entity name="damage_received.mild_damage_voice">
   <AudioComponent file="mods/akanechan_voice/files/audio/mod_voices.snd"
     event_root="akanechan"
     audio_physics_material="character_player"

--- a/files/entities/sounds/damage_received/on_fire_damage_voice.xml
+++ b/files/entities/sounds/damage_received/on_fire_damage_voice.xml
@@ -1,4 +1,4 @@
-<Entity name="start_voice">
+<Entity name="damage_received.on_fire_damage_voice">
   <AudioComponent file="mods/akanechan_voice/files/audio/mod_voices.snd"
     event_root="akanechan"
     audio_physics_material="character_player"

--- a/files/entities/sounds/enemy/pickup/wand.xml
+++ b/files/entities/sounds/enemy/pickup/wand.xml
@@ -1,4 +1,4 @@
-<Entity name="start_voice">
+<Entity name="enemy.pickup.wand">
   <AudioComponent file="mods/akanechan_voice/files/audio/mod_voices.snd"
     event_root="akanechan"
     audio_physics_material="character_player"

--- a/files/entities/sounds/kick_voice.xml
+++ b/files/entities/sounds/kick_voice.xml
@@ -1,4 +1,4 @@
-<Entity name="start_voice">
+<Entity name="kick_voice">
   <AudioComponent file="mods/akanechan_voice/files/audio/mod_voices.snd"
     event_root="akanechan"
     audio_physics_material="character_player"

--- a/files/entities/sounds/pickup/refresher.xml
+++ b/files/entities/sounds/pickup/refresher.xml
@@ -1,4 +1,4 @@
-<Entity name="refresher">
+<Entity name="pickup.refresher">
   <AudioComponent file="mods/akanechan_voice/files/audio/mod_voices.snd"
     event_root="akanechan"
     audio_physics_material="character_player"

--- a/files/entities/sounds/pickup/shop_wand.xml
+++ b/files/entities/sounds/pickup/shop_wand.xml
@@ -1,4 +1,4 @@
-<Entity name="start_voice">
+<Entity name="pickup.shop_wand">
   <AudioComponent file="mods/akanechan_voice/files/audio/mod_voices.snd"
     event_root="akanechan"
     audio_physics_material="character_player"

--- a/files/entities/sounds/pickup/temple_health.xml
+++ b/files/entities/sounds/pickup/temple_health.xml
@@ -1,4 +1,4 @@
-<Entity name="refresher">
+<Entity name="pickup.temple_health">
   <AudioComponent file="mods/akanechan_voice/files/audio/mod_voices.snd"
     event_root="akanechan"
     audio_physics_material="character_player"

--- a/files/entities/sounds/pickup/wand.xml
+++ b/files/entities/sounds/pickup/wand.xml
@@ -1,4 +1,4 @@
-<Entity name="start_voice">
+<Entity name="pickup.wand">
   <AudioComponent file="mods/akanechan_voice/files/audio/mod_voices.snd"
     event_root="akanechan"
     audio_physics_material="character_player"

--- a/files/entities/sounds/throw/emerald_tablet_voice.xml
+++ b/files/entities/sounds/throw/emerald_tablet_voice.xml
@@ -1,4 +1,4 @@
-<Entity name="start_voice">
+<Entity name="throw.emerald_tablet_voice">
   <AudioComponent file="mods/akanechan_voice/files/audio/mod_voices.snd"
     event_root="akanechan"
     audio_physics_material="character_player"

--- a/files/entities/sounds/throw/item_voice.xml
+++ b/files/entities/sounds/throw/item_voice.xml
@@ -1,4 +1,4 @@
-<Entity name="start_voice">
+<Entity name="throw.item_voice">
   <AudioComponent file="mods/akanechan_voice/files/audio/mod_voices.snd"
     event_root="akanechan"
     audio_physics_material="character_player"

--- a/files/entities/sounds/throw/wand_voice.xml
+++ b/files/entities/sounds/throw/wand_voice.xml
@@ -1,4 +1,4 @@
-<Entity name="start_voice">
+<Entity name="throw.wand_voice">
   <AudioComponent file="mods/akanechan_voice/files/audio/mod_voices.snd"
     event_root="akanechan"
     audio_physics_material="character_player"

--- a/files/scripts/lib/utils/sound_player.lua
+++ b/files/scripts/lib/utils/sound_player.lua
@@ -70,6 +70,20 @@ SoundPlayer = {
     return nil
   end,
 
+  destroySoundPlayer = function(self, parent_entity_id, sound_player_name)
+    if parent_entity_id == nil then
+      return false
+    end
+
+    for _, child_entity_id in ipairs(EntityGetAllChildren(parent_entity_id)) do
+      if EntityGetName(child_entity_id) == sound_player_name then
+        EntityKill(child_entity_id)
+      end
+    end
+
+    return true
+  end,
+
   registerSoundEntity = function(self, sound_player_entity_id, xml_file_name)
     self:_registerSoundEntity(sound_player_entity_id, xml_file_name, nil)
   end,

--- a/files/scripts/player/throw_item.lua
+++ b/files/scripts/player/throw_item.lua
@@ -1,7 +1,7 @@
 dofile_once("mods/akanechan_voice/files/scripts/lib/utilities.lua")
 
 function throw_item(from_x, from_y, to_x, to_y)
-  print("throw item")
+  p("throw item")
   local player_pos_x, player_pos_y = EntityGetTransform(getPlayerEntity())
   local r = math.floor(calcRadius(player_pos_x, player_pos_y, from_x, from_y) + 0.5)
   if r <= 9 then
@@ -11,7 +11,6 @@ end
 
 function throwing_item()
   local player_entity_id = getPlayerEntity()
-
   local akanechan_voice = SoundPlayer:seachSoundPlayer(player_entity_id, AKANECHAN.SOUND_PLAYER_NAME)
   SoundPlayer:registerOnlyEmptySoundEntity(akanechan_voice, "mods/akanechan_voice/files/entities/sounds/throw/item_voice.xml")
 end

--- a/init.lua
+++ b/init.lua
@@ -2,12 +2,19 @@ dofile_once("mods/akanechan_voice/files/scripts/lib/utilities.lua")
 
 print("akanechan_voice load")
 
+function OnModInit()
+  -- 音声ファイルロード
+  dofile("mods/akanechan_voice/files/scripts/load_extends_voice.lua")
+end
+
 function OnPlayerSpawned(player_entity_id)
+  local player_entity_id = getPlayerEntity()
+
+  SoundPlayer:destroySoundPlayer(player_entity_id, AKANECHAN.SOUND_PLAYER_NAME)
+  AkanechanVoice = SoundPlayer:create(player_entity_id, AKANECHAN.SOUND_PLAYER_NAME, AKANECHAN:SOUND_FILE_STORAGE_NAME())
+
   local loaded = getInternalVariableValue(player_entity_id, "akanechan_voice.loaded?", "value_bool") or false
   if not loaded then
-    local player_entity_id = getPlayerEntity()
-    AkanechanVoice = SoundPlayer:create(player_entity_id, AKANECHAN.SOUND_PLAYER_NAME, AKANECHAN:SOUND_FILE_STORAGE_NAME())
-
     -- spawn時にアクションを行いたいため、xml拡張ではなくentityに対しての代入となっている
     EntityLoadToEntity("mods/akanechan_voice/files/entities/extend_player_voices.xml", player_entity_id)
     addNewInternalVariable(player_entity_id, "akanechan_voice.loaded?", "value_bool", true)
@@ -20,8 +27,6 @@ function OnWorldPreUpdate()
   end
 end
 
-
--- 音声ファイルロード
-dofile_once("mods/akanechan_voice/files/scripts/load_extends_voice.lua")
-
 print("akanechan_voice loaded")
+
+


### PR DESCRIPTION
再ロード時に茜ちゃんが再定義されていないことが問題でした。
またloaded外に設置した場合SoundPlayerEntityが複数生成されてしまうので、
ロード前に削除を行っています。

close #28